### PR TITLE
let pystr_format handle a data.frame parameter

### DIFF
--- a/R/pystr_format.R
+++ b/R/pystr_format.R
@@ -8,10 +8,14 @@
 #' a copy of the string where each replacement field is replaced with the string value of the
 #' corresponding argument.
 #'
+#' If \code{...} as a single argument of a \code{data.frame}-like object, \code{pystr_format} will
+#' return an \code{nrow()}-length character vector using the column names of the data.frame for
+#' the named \code{\{placeholder\}}s.
+#'
 #' @param str A string.
 #' @param ... Parameter values. See details and examples
 #'
-#' @return A formatted string.
+#' @return A formatted character vector.
 #'
 #' @references \url{https://docs.python.org/3/library/stdtypes.html#str.format}
 #'
@@ -35,11 +39,24 @@
 #' ## Placeholders can be used more than once
 #'
 #' pystr_format("The name is {last}. {first} {last}.", last="Bond", first="James")
-
+#'
+#' ## Pass in a whole data frame, matching by column
+#'
+#' my_cars <- data.frame(car=rownames(mtcars), mtcars)
+#' head(pystr_format("The {car} gets {mpg} mpg (hwy) despite having {cyl} cylinders.", my_cars))
+#'
+#' ## perhaps a more practical example?
+#'
+#' supers <- data.frame(first=c("Bruce", "Hal", "Clark", "Diana"),
+#'                      last=c("Wayne", "Jordan", "Kent", "Prince"),
+#'                      is=c("Batman", "Green Lantern", "Superman", "Wonder Woman"))
+#' pystr_format("{first} {last} is really {is} but you shouldn't call them {first} in public.", supers)
+#'
 #' @export
 pystr_format <- function(str, ...) {
   args = list(...)
 
+  # if nothing was passed in besides 'str'
   if(length(args) == 0) {
     return(str)
   }
@@ -47,6 +64,29 @@ pystr_format <- function(str, ...) {
   params = args
 
   if(length(args) == 1) {
+
+    if (inherits(args[[1]], "data.frame")) {
+
+      # convert whatever else it may be besides a data.frame to a data.frame
+      # to avoid return type issues with tbl_'s and with= nonsense with data.table
+      df <- data.frame(args[[1]], stringsAsFactors=FALSE, check.names=FALSE)
+
+      pat <-  "\\{[[:alnum:]]+\\}"
+      looking_for <- gsub("[\\{\\}]", "", regmatches(str, gregexpr(pat, str))[[1]])
+      has <- colnames(df)
+      will_replace <- intersect(looking_for, has)
+      if (length(will_replace) > 0) {
+        sapply(1:nrow(df), function(i) {
+          res <- str
+          for(repl in will_replace) res <- gsub(sprintf("\\{%s\\}", repl), df[i, repl], res)
+          res
+        }) -> out
+        return(out)
+
+      }
+
+    }
+
     if(is.null(names(args))) {
       params = args[[1]]
     }

--- a/man/pystr_format.Rd
+++ b/man/pystr_format.Rd
@@ -12,7 +12,7 @@ pystr_format(str, ...)
 \item{...}{Parameter values. See details and examples}
 }
 \value{
-A formatted string.
+A formatted character vector.
 }
 \description{
 Perform a string formatting operation.
@@ -23,6 +23,10 @@ literal text or replacement fields delimited by braces \code{\{\}}. Each replace
 either the numeric index of a positional argument, or the name of a keyword argument. Returns
 a copy of the string where each replacement field is replaced with the string value of the
 corresponding argument.
+
+If \code{...} as a single argument of a \code{data.frame}-like object, \code{pystr_format} will
+return an \code{nrow()}-length character vector using the column names of the data.frame for
+the named \code{\{placeholder\}}s.
 }
 \examples{
 # Numeric placeholders
@@ -44,6 +48,18 @@ pystr_format("Hello {name}, you have {n} new notifications!", name="Nicole", n=2
 ## Placeholders can be used more than once
 
 pystr_format("The name is {last}. {first} {last}.", last="Bond", first="James")
+
+## Pass in a whole data frame, matching by column
+
+my_cars <- data.frame(car=rownames(mtcars), mtcars)
+head(pystr_format("The {car} gets {mpg} mpg (hwy) despite having {cyl} cylinders.", my_cars))
+
+## perhaps a more practical example?
+
+supers <- data.frame(first=c("Bruce", "Hal", "Clark", "Diana"),
+                     last=c("Wayne", "Jordan", "Kent", "Prince"),
+                     is=c("Batman", "Green Lantern", "Superman", "Wonder Woman"))
+pystr_format("{first} {last} is really {is} but you shouldn't call them {first} in public.", supers)
 }
 \references{
 \url{https://docs.python.org/3/library/stdtypes.html#str.format}


### PR DESCRIPTION
This is a small addition, but if `...` is a `data.frame`, have `pystr_format` use the column names from the data frame to return an `nrow()`-length character vector substituting the `{}` named parameters with the values in the rows of the data.frame. 

A trivial but illustrative example:

    library(pystr)
    supers <- data.frame(first=c("Bruce", "Hal", "Clark", "Diana"),
                         last=c("Wayne", "Jordan", "Kent", "Prince"),
                         is=c("Batman", "Green Lantern", "Superman", "Wonder Woman"))
    pystr_format("{first} {last} is really {is} but you shouldn't call them {first} in public.", supers)

    ## [1] "Bruce Wayne is really Batman but you shouldn't call them Bruce in public."       
    ## [2] "Hal Jordan is really Green Lantern but you shouldn't call them Hal in public."   
    ## [3] "Clark Kent is really Superman but you shouldn't call them Clark in public."      
    ## [4] "Diana Prince is really Wonder Woman but you shouldn't call them Diana in public."

I think I can add vectorization to the other bits of this function as well if desired.